### PR TITLE
Fix a bug in the InputStream

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -51,6 +51,7 @@ InputStream.prototype._data = function (chunk) {
 };
 
 InputStream.prototype._read = function (size) {
+    this._canPush = true;
     while (this._buffer.length && (this._canPush = this.push(this._buffer.shift())));
 };
 


### PR DESCRIPTION
I encountered a problem when sending some larger HTTP packets (a file upload) to this FastCGI server. For some reason, the `"data"` event would only fire once and the rest of the data would be buffered and not emitted. This single line fixed the issue, by setting `_canPush` to true, even if no data is buffered. A call to `_read` is a signal that more data is requested and that more data can therefore be pushed.